### PR TITLE
Add uniqueAppInstanceIdentifier method

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,8 +3,8 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:rim="http://www.blackberry.com/ns/widgets"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="com.feedhenry.plugin.device"
-    version="0.0.2">
+    id="fh-cordova-plugin-device"
+    version="0.0.3">
     <name>FHDevice</name>
     <description>The plugin contains device info used by FeedHenry</description>
 

--- a/src/ios/FHDevice.m
+++ b/src/ios/FHDevice.m
@@ -33,11 +33,10 @@
 
 - (NSDictionary*)deviceProperties
 {
-    UIDevice* device = [UIDevice currentDevice];
     NSMutableDictionary* devProps = [NSMutableDictionary dictionaryWithCapacity:4];
 
     //the change here was to use the category on UIDevice imported above
-    [devProps setObject:[device uniqueAppInstanceIdentifier] forKey:@"uuid"];
+    [devProps setObject:[self uniqueAppInstanceIdentifier] forKey:@"uuid"];
       
     // Generate cuidMap
     NSMutableArray *cuidMap = [[NSMutableArray alloc] init];
@@ -58,6 +57,28 @@
 
     NSDictionary* devReturn = [NSDictionary dictionaryWithDictionary:devProps];
     return devReturn;
+}
+
+- (NSString*)uniqueAppInstanceIdentifier
+{
+    NSUserDefaults* userDefaults = [NSUserDefaults standardUserDefaults];
+    static NSString* UUID_KEY = @"CDVUUID";
+
+    NSString* app_uuid = [userDefaults stringForKey:UUID_KEY];
+
+    if (app_uuid == nil) {
+        CFUUIDRef uuidRef = CFUUIDCreate(kCFAllocatorDefault);
+        CFStringRef uuidString = CFUUIDCreateString(kCFAllocatorDefault, uuidRef);
+
+        app_uuid = [NSString stringWithString:(__bridge NSString*)uuidString];
+        [userDefaults setObject:app_uuid forKey:UUID_KEY];
+        [userDefaults synchronize];
+
+        CFRelease(uuidString);
+        CFRelease(uuidRef);
+    }
+
+    return app_uuid;
 }
 
 @end


### PR DESCRIPTION
The uniqueAppInstanceIdentifier method has been removed on cordova-ios 4, (the class that had it), so I'm adding the code here so the plugin continues working on cordova-ios 4
Also bumped the version and changed the id 